### PR TITLE
Replace all literal occurrences of actual* with current*

### DIFF
--- a/src/Syw/Front/MainBundle/Command/GetWorldPopulationCommand.php
+++ b/src/Syw/Front/MainBundle/Command/GetWorldPopulationCommand.php
@@ -31,10 +31,10 @@ class GetWorldPopulationCommand extends ContainerAwareCommand
     {
         $this
             ->setName('syw:get:worldpopulation')
-            ->setDescription('Gets the actual world population')
+            ->setDescription('Gets the current world population')
             ->setDefinition(array())
             ->setHelp(<<<EOT
-The <info>syw:get:worldpopulation</info> gets the actual world population
+The <info>syw:get:worldpopulation</info> gets the current world population
 
 EOT
             );

--- a/src/Syw/Front/MainBundle/Controller/SignatureImagesController.php
+++ b/src/Syw/Front/MainBundle/Controller/SignatureImagesController.php
@@ -71,7 +71,7 @@ class SignatureImagesController extends BaseController
                 imagestring($imNeu, 3, 20, 55, "Registered Linux user since ".$createdat."", $black);
                 imagestring($imNeu, 5, 70, 78, "Linux User #".$thisuser->getId(), $black);
                 imagestring($imNeu, 2, 20, 104, "This user has ".$machine_count." Linux machines registered.", $black);
-                imagestring($imNeu, 2, 20, 116, "".$machinesonline_count." Linux machines are actually online.", $black);
+                imagestring($imNeu, 2, 20, 116, "".$machinesonline_count." Linux machines are currently online.", $black);
                 imagestring($imNeu, 1, 110, 134, "A free service from linuxcounter.net", $black);
                 imagepng($imNeu, $cert);
             }

--- a/src/Syw/Front/MainBundle/Controller/StatsController.php
+++ b/src/Syw/Front/MainBundle/Controller/StatsController.php
@@ -39,7 +39,7 @@ class StatsController extends BaseController
             'accountInfo' => $this->getAccountInfo(),
             'online' => $online,
             'metatitle' => $metatitle,
-            'metadescription' => $this->get('translator')->trans('See here how many linux users there are in the world and how many users and machines actually are registered to the Linux Counter', array(), 'syw_front_main_main_index'),
+            'metadescription' => $this->get('translator')->trans('See here how many linux users there are in the world and how many users and machines are currently registered to the Linux Counter', array(), 'syw_front_main_main_index'),
             'title1' => $title1,
             'title2' => $title2,
             'languages' => $languages,

--- a/src/Syw/Front/MainBundle/EventListener/IrcBotImportListener.php
+++ b/src/Syw/Front/MainBundle/EventListener/IrcBotImportListener.php
@@ -36,7 +36,7 @@ class IrcBotImportListener extends CommandListener
 
         $running = @exec('ps ax | grep "syw:import:lico" | grep -v grep');
         if (trim($running) == "") {
-            $msg = "There is actually no import running.";
+            $msg = "There is currently no import running.";
             $this->sendMessage(array($event->getChannel()), $msg);
         } else {
             $qb = $this->em->createQueryBuilder();
@@ -49,7 +49,7 @@ class IrcBotImportListener extends CommandListener
             $qb->from('SywFrontMainBundle:Machines', 'machines');
             $mCount = $qb->getQuery()->getSingleScalarResult();
 
-            $msg = "There are actually ".number_format($uCount)." users and ".number_format($mCount)." machines imported, out of around 600,000 users.";
+            $msg = "There are currently ".number_format($uCount)." users and ".number_format($mCount)." machines imported, out of around 600,000 users.";
             $this->sendMessage(array($event->getChannel()), $msg);
 
 

--- a/src/Syw/Front/MainBundle/Form/Type/MachineFormType.php
+++ b/src/Syw/Front/MainBundle/Form/Type/MachineFormType.php
@@ -71,7 +71,7 @@ class MachineFormType extends AbstractType
             ->add('mailer', 'text', array('label' => 'Mailer software', 'required' => false))
             ->add('network', 'text', array('label' => 'Network', 'required' => false))
             ->add('accounts', 'text', array('label' => 'Number of Accounts', 'required' => false))
-            ->add('uptime', 'text', array('label' => 'Actual Uptime', 'required' => false))
+            ->add('uptime', 'text', array('label' => 'Current Uptime', 'required' => false))
             ->add('loadavg', 'text', array('label' => 'Load average', 'required' => false))
 
             ->add('save', 'submit');


### PR DESCRIPTION
I've replaced all occurrences of "actual" and variants like "actually"
in string literals with "current" and "currently".  This usage of
"actual" is a common mistake because it looks like the German word
"aktuell", but for information that is fresh and up-to-date about the
present we use "current", whereas "actually" is closer to "eigentlich".